### PR TITLE
fix: when using s3, detect if prefix contains subfolders or individual backup files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,34 @@ Thanks to xolox for his work on [rotate-backups](https://github.com/xolox/python
 
 ## Usage
 
-| Option                      | Description                                                                                    | Default Value            |
-| --------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------ |
-| `--minutely`                | Number of minutely backups to preserve                                                         | `0`                      |
-| `--hourly`                  | Number of hourly backups to preserve                                                           | `72`                     |
-| `--daily`                   | Number of daily backups to preserve                                                            | `7`                      |
-| `--weekly`                  | Number of weekly backups to preserve                                                           | `6`                      |
-| `--monthly`                 | Number of monthly backups to preserve                                                          | `12`                     |
-| `--yearly`                  | Number of yearly backups to preserve                                                           | `always`                 |
-| `-c`, `--config`            | Location of the config file                                                                    | `/etc/backup_warden.ini` |
-| `-s`, `--source`            | Source of where the backups are stored. Select from: `local`, `ssh`, `s3`                      | `local`                  |
-| `-b`, `--bucket`            | Name of the AWS S3 bucket                                                                      |                          |
-| `-p`, `--path`              | Specify a path to traverse all directories it contains for granular retention policies         |                          |
-| `-e`, `--environment`       | Environment the backups are rotated in (used for Slack alert only)                             |                          |
-| `-t`, `--timestamp-pattern` | The timestamp pattern using a regex expression to parse out of filenames                       |                          |
-| `-l`, `--log-file`          | Enable logging to this file path                                                               |                          |
-| `-I`, `--include`           | Include backups based on their directory path and/or filename (separated by comma)             |                          |
-| `-E`, `--exclude`           | Exclude backups based on their directory path and/or filename (separated by comma)             |                          |
-| `-H`, `--ssh-host`          | SSH host/alias to use                                                                          |                          |
-| `--ssh-sudo`                | Wrap SSH commands with sudo for escalated privileges                                           | `False`                  |
-| `--filestat`                | Use the file's last modified date instead of parsing timestamp from filename                   | `False`                  |
-| `--prefer-recent`           | Keep the most recent backup in each time slot instead of oldest                                | `False`                  |
-| `--relaxed`                 | Time windows are not enforced                                                                  | `False`                  |
-| `--utc`                     | Use UTC timezone instead of local machine's timezone for timestamps                            | `False`                  |
-| `--syslog`                  | Use syslog                                                                                     | `False`                  |
-| `--debug`                   | Log debug messages that can help troubleshoot                                                  | `False`                  |
-| `--delete`                  | Commit to deleting backups (DANGER ZONE)                                                       | `False`                  |
-| `-V`, `--version`           | Display version and exit                                                                       |                          |
-| `-h`, `--help`              | Show this help message and exit                                                                |                          |
+| Option                      | Description                                                                            | Default Value            |
+|-----------------------------|----------------------------------------------------------------------------------------|--------------------------|
+| `--minutely`                | Number of minutely backups to preserve                                                 | `0`                      |
+| `--hourly`                  | Number of hourly backups to preserve                                                   | `72`                     |
+| `--daily`                   | Number of daily backups to preserve                                                    | `7`                      |
+| `--weekly`                  | Number of weekly backups to preserve                                                   | `6`                      |
+| `--monthly`                 | Number of monthly backups to preserve                                                  | `12`                     |
+| `--yearly`                  | Number of yearly backups to preserve                                                   | `always`                 |
+| `-c`, `--config`            | Location of the config file                                                            | `/etc/backup_warden.ini` |
+| `-s`, `--source`            | Source of where the backups are stored. Select from: `local`, `ssh`, `s3`              | `local`                  |
+| `-b`, `--bucket`            | Name of the AWS S3 bucket                                                              |                          |
+| `-p`, `--path`              | Specify a path to traverse all directories it contains for granular retention policies |                          |
+| `-e`, `--environment`       | Environment the backups are rotated in (used for Slack alert only)                     |                          |
+| `-t`, `--timestamp-pattern` | The timestamp pattern using a regex expression to parse out of filenames               |                          |
+| `-l`, `--log-file`          | Enable logging to this file path                                                       |                          |
+| `-I`, `--include`           | Include backups based on their directory path and/or filename (separated by comma)     |                          |
+| `-E`, `--exclude`           | Exclude backups based on their directory path and/or filename (separated by comma)     |                          |
+| `-H`, `--ssh-host`          | SSH host/alias to use                                                                  |                          |
+| `--ssh-sudo`                | Wrap SSH commands with sudo for escalated privileges                                   | `False`                  |
+| `--filestat`                | Use the file's last modified date instead of parsing timestamp from filename           | `False`                  |
+| `--prefer-recent`           | Keep the most recent backup in each time slot instead of oldest                        | `False`                  |
+| `--relaxed`                 | Time windows are not enforced                                                          | `False`                  |
+| `--utc`                     | Use UTC timezone instead of local machine's timezone for timestamps                    | `False`                  |
+| `--syslog`                  | Use syslog                                                                             | `False`                  |
+| `--debug`                   | Log debug messages that can help troubleshoot                                          | `False`                  |
+| `--delete`                  | Commit to deleting backups (DANGER ZONE)                                               | `False`                  |
+| `-V`, `--version`           | Display version and exit                                                               |                          |
+| `-h`, `--help`              | Show this help message and exit                                                        |                          |
 
 **Note**: Boolean options such as `--filestat` can be specified as `yes`/`no`, `true`/`false`, or `1`/`0` in the config
 

--- a/backup_warden/__init__.py
+++ b/backup_warden/__init__.py
@@ -364,7 +364,6 @@ class BackupWarden:
                 objects += page["CommonPrefixes"]
 
             for obj in objects:
-                logger.info(obj)
                 if "Key" in obj:
                     backup_path = Path(obj["Key"])
                     backup_size = obj["Size"]

--- a/backup_warden/__init__.py
+++ b/backup_warden/__init__.py
@@ -359,7 +359,7 @@ class BackupWarden:
             objs = []
             if "Contents" in page:
                 # If we get "Contents" back, then it's a listing of individual files
-                objs = page.Get("Contents")
+                objs = page["Contents"]
             elif "CommonPrefixes" in page:
                 # Otherwise, we got back a listing of prefixes in the directory and will treat those as the backups
                 key = "Prefix"

--- a/example_configs/s3.ini
+++ b/example_configs/s3.ini
@@ -2,7 +2,7 @@
 path = /backup-warden/backups
 environment = prod
 source = s3
-s3_access_key_id = 
+s3_access_key_id =
 s3_secret_access_key =
 s3_session_token =
 


### PR DESCRIPTION
Resolves #9 by passing a [Delimiter to the list_objects_v2](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/list_objects_v2.html) operation. When a delimiter is given, the operation only lists objects/prefixes that are in the specified prefix (not recursive to all sub-prefixes). Then we can append the objects *and* sub-prefixes to the list of potential backups. 

This should allow it to handle situations such as:
- s3 bucket that has backups deeply nested under a timestamped prefix, such as `2024-12-25/my-db/my-table/backup.sql`
- s3 bucket with mix of sub-prefixes and backup files under the same prefix