### PR TITLE
Option to only list prefixes to improve performance on buckets with many objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,35 @@ Thanks to xolox for his work on [rotate-backups](https://github.com/xolox/python
 
 ## Usage
 
-| Option                      | Description                                                                                    | Default Value            |
-| --------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------ |
-| `--minutely`                | Number of minutely backups to preserve                                                         | `0`                      |
-| `--hourly`                  | Number of hourly backups to preserve                                                           | `72`                     |
-| `--daily`                   | Number of daily backups to preserve                                                            | `7`                      |
-| `--weekly`                  | Number of weekly backups to preserve                                                           | `6`                      |
-| `--monthly`                 | Number of monthly backups to preserve                                                          | `12`                     |
-| `--yearly`                  | Number of yearly backups to preserve                                                           | `always`                 |
-| `-c`, `--config`            | Location of the config file                                                                    | `/etc/backup_warden.ini` |
-| `-s`, `--source`            | Source of where the backups are stored. Select from: `local`, `ssh`, `s3`                      | `local`                  |
-| `-b`, `--bucket`            | Name of the AWS S3 bucket                                                                      |                          |
-| `-p`, `--path`              | Specify a path to traverse all directories it contains for granular retention policies         |                          |
-| `-e`, `--environment`       | Environment the backups are rotated in (used for Slack alert only)                             |                          |
-| `-t`, `--timestamp-pattern` | The timestamp pattern using a regex expression to parse out of filenames                       |                          |
-| `-l`, `--log-file`          | Enable logging to this file path                                                               |                          |
-| `-I`, `--include`           | Include backups based on their directory path and/or filename (separated by comma)             |                          |
-| `-E`, `--exclude`           | Exclude backups based on their directory path and/or filename (separated by comma)             |                          |
-| `-H`, `--ssh-host`          | SSH host/alias to use                                                                          |                          |
-| `--ssh-sudo`                | Wrap SSH commands with sudo for escalated privileges                                           | `False`                  |
-| `--filestat`                | Use the file's last modified date instead of parsing timestamp from filename                   | `False`                  |
-| `--prefer-recent`           | Keep the most recent backup in each time slot instead of oldest                                | `False`                  |
-| `--relaxed`                 | Time windows are not enforced                                                                  | `False`                  |
-| `--utc`                     | Use UTC timezone instead of local machine's timezone for timestamps                            | `False`                  |
-| `--syslog`                  | Use syslog                                                                                     | `False`                  |
-| `--debug`                   | Log debug messages that can help troubleshoot                                                  | `False`                  |
-| `--delete`                  | Commit to deleting backups (DANGER ZONE)                                                       | `False`                  |
-| `-V`, `--version`           | Display version and exit                                                                       |                          |
-| `-h`, `--help`              | Show this help message and exit                                                                |                          |
+| Option                      | Description                                                                            | Default Value            |
+|-----------------------------|----------------------------------------------------------------------------------------|--------------------------|
+| `--minutely`                | Number of minutely backups to preserve                                                 | `0`                      |
+| `--hourly`                  | Number of hourly backups to preserve                                                   | `72`                     |
+| `--daily`                   | Number of daily backups to preserve                                                    | `7`                      |
+| `--weekly`                  | Number of weekly backups to preserve                                                   | `6`                      |
+| `--monthly`                 | Number of monthly backups to preserve                                                  | `12`                     |
+| `--yearly`                  | Number of yearly backups to preserve                                                   | `always`                 |
+| `-c`, `--config`            | Location of the config file                                                            | `/etc/backup_warden.ini` |
+| `-s`, `--source`            | Source of where the backups are stored. Select from: `local`, `ssh`, `s3`              | `local`                  |
+| `-b`, `--bucket`            | Name of the AWS S3 bucket                                                              |                          |
+| `-p`, `--path`              | Specify a path to traverse all directories it contains for granular retention policies |                          |
+| `-e`, `--environment`       | Environment the backups are rotated in (used for Slack alert only)                     |                          |
+| `-t`, `--timestamp-pattern` | The timestamp pattern using a regex expression to parse out of filenames               |                          |
+| `-l`, `--log-file`          | Enable logging to this file path                                                       |                          |
+| `-I`, `--include`           | Include backups based on their directory path and/or filename (separated by comma)     |                          |
+| `-E`, `--exclude`           | Exclude backups based on their directory path and/or filename (separated by comma)     |                          |
+| `-H`, `--ssh-host`          | SSH host/alias to use                                                                  |                          |
+| `--ssh-sudo`                | Wrap SSH commands with sudo for escalated privileges                                   | `False`                  |
+| `--filestat`                | Use the file's last modified date instead of parsing timestamp from filename           | `False`                  |
+| `--prefer-recent`           | Keep the most recent backup in each time slot instead of oldest                        | `False`                  |
+| `--s3-only-prefixes`        | When used with an S3 bucket, only prefixes will be considered (not individual objects) | `False`                  |
+| `--relaxed`                 | Time windows are not enforced                                                          | `False`                  |
+| `--utc`                     | Use UTC timezone instead of local machine's timezone for timestamps                    | `False`                  |
+| `--syslog`                  | Use syslog                                                                             | `False`                  |
+| `--debug`                   | Log debug messages that can help troubleshoot                                          | `False`                  |
+| `--delete`                  | Commit to deleting backups (DANGER ZONE)                                               | `False`                  |
+| `-V`, `--version`           | Display version and exit                                                               |                          |
+| `-h`, `--help`              | Show this help message and exit                                                        |                          |
 
 **Note**: Boolean options such as `--filestat` can be specified as `yes`/`no`, `true`/`false`, or `1`/`0` in the config
 
@@ -115,6 +116,10 @@ Backup Warden offers the `--relaxed` option to modify its default rotation behav
 
 - **Relaxed Rotation**: With the `--relaxed` option enabled, the three most recent backups will all match the hourly frequency and be preserved, regardless of the calculated time window. Choose this option if your backups are created at irregular intervals, as it allows for the preservation of more backups
 
+#### Option: `s3-only-prefixes`
+
+With the `--s3-only-prefixes` option, only prefixes (not individual objects) will be considered for rotation. This drastically improves performance when the bucket contains a large number of objects, but only works if your backups are nested under timestamped prefixes.
+
 #### Option: `include-list`/`exclude-list`
 
 These options utilize `fnmatch`, allowing the use of asterisks as wildcards. This enables precise definition of which backups should be excluded from deletion. Include and exclude can be used together for fine-grained control.
@@ -179,6 +184,7 @@ Under the `[main]` section in the config file, you can set the following options
 - `s3_endpoint_url`
 - `s3_access_key_id`
 - `s3_secret_access_key`
+- `s3_only_prefixes`
 - `slack_webhook`
 
 For each config `[path]` section, you can set the following options:

--- a/backup_warden/app.py
+++ b/backup_warden/app.py
@@ -255,6 +255,11 @@ def setup_options():
         help="Time windows are not enforced (see documentation for more information)",
     )
     parser.add_argument(
+        "--s3-only-prefixes",
+        action="store_true",
+        help="Only considers prefixes, not individual objects, for rotation",
+    )
+    parser.add_argument(
         "--utc", action="store_true", help="Use UTC timezone instead of local machine's timezone for timestamps"
     )
     parser.add_argument(
@@ -329,6 +334,7 @@ def setup_options():
                 s3_access_key_id=main_config.get("s3_access_key_id"),
                 s3_secret_access_key=main_config.get("s3_secret_access_key"),
                 s3_session_token=main_config.get("s3_session_token"),
+                s3_only_prefixes=main_config.get("s3_only_prefixes"),
             )
             args.__dict__.update(config_options.__dict__)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "backup_warden"
-version = "1.0.8"
+version = "1.0.9"
 description = "Streamline your backup management with ease and simplicity"
 authors = ["Charles Thompson <01charles.t@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Our production DB backup bucket currently has around ~6 million objects (we use mysql shell dumpInstance, which produces hundreds or thousands of files for each table). When attempting to run `backup-warden` on the bucket, it takes a _very_ long time fetching all the objects from S3 API. To improve performance, I added this flag which uses the delimiter option to fetch only prefixes (and not individual objects) from the API. Then the whole operation goes from taking several minutes to less than a second.

Also, I'm not attached to `--s3-only-prefixes` being the name of the flag, better ideas welcome!