### PR TITLE
fix: handle deleting >1000 keys; prefix recursive delete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "backup_warden"
-version = "1.0.11"
+version = "1.0.12"
 description = "Streamline your backup management with ease and simplicity"
 authors = ["Charles Thompson <01charles.t@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Handles a scenario where more than 1000 objects need to be deleted by iterating over chunks of 1000 to delete them
- Handles s3-only-prefixes deletion correctly by doing a recursive delete of all objects in each prefix