### PR TITLE
fix bulk deletion for s3 prefixes

### DIFF
--- a/backup_warden/__init__.py
+++ b/backup_warden/__init__.py
@@ -807,7 +807,13 @@ class BackupWarden:
                 # We bulk delete for S3 since it has better performance
                 if self.delete and s3_delete_list:
                     if self.s3_only_prefixes:
-                        s3 = boto3.resource("s3")
+                        s3 = boto3.resource(
+                            "s3",
+                            endpoint_url=self.s3_endpoint_url,
+                            aws_access_key_id=self.s3_access_key_id,
+                            aws_secret_access_key=self.s3_secret_access_key,
+                            aws_session_token=self.s3_session_token,
+                        )
                         bucket = s3.Bucket(self.bucket)
                         for item in s3_delete_list:
                             try:


### PR DESCRIPTION
the boto3 resource is instantiated without configuration from the file, which leads to _listing_ what needs to be deleted succeeding while actually performing the delete failes.

i'm able to work around this by exporting AWS_* env vars, but the delete should operate with the same credentials as the list